### PR TITLE
#6: Added PUT method to /joke/:id endpoint

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -10,6 +10,7 @@ use crate::*;
         get_joke,
         post_joke,
         delete_joke,
+        update_joke,
     ),
     components(
         schemas(Joke, JokeBaseError)
@@ -99,6 +100,30 @@ pub async fn delete_joke(
     Path(joke_id): Path<String>,
 ) -> Response {
     match jokebase.write().await.delete(&joke_id) {
+        Ok(()) => StatusCode::OK.into_response(),
+        Err(e) => JokeBaseError::response(StatusCode::BAD_REQUEST, e),
+    }
+}
+
+#[utoipa::path(
+    put,
+    path = "/api/v1/joke/{id}",
+    request_body(
+        content = inline(Joke),
+        description = "Joke to update"
+    ),
+    responses(
+        (status = 200, description = "Updated joke", body = ()),
+        (status = 201, description = "Added joke", body = ()),
+        (status = 400, description = "Bad request", body = JokeBaseError),
+    )
+)]
+pub async fn update_joke(
+    State(jokebase): State<Arc<RwLock<JokeBase>>>,
+    Path(joke_id): Path<String>,
+    Json(joke): Json<Joke>,
+) -> Response {
+    match jokebase.write().await.update(&joke_id, joke) {
         Ok(()) => StatusCode::OK.into_response(),
         Err(e) => JokeBaseError::response(StatusCode::BAD_REQUEST, e),
     }

--- a/src/api.rs
+++ b/src/api.rs
@@ -73,7 +73,7 @@ pub async fn get_joke(
         description = "Joke to add"
     ),
     responses(
-        (status = 200, description = "Added joke", body = ()),
+        (status = 201, description = "Added joke", body = ()),
         (status = 400, description = "Bad request", body = JokeBaseError)
     )
 )]
@@ -124,7 +124,13 @@ pub async fn update_joke(
     Json(joke): Json<Joke>,
 ) -> Response {
     match jokebase.write().await.update(&joke_id, joke) {
-        Ok(()) => StatusCode::OK.into_response(),
+        Ok(res) => {
+            if res == 200 {
+                StatusCode::OK.into_response()
+            } else {
+                StatusCode::CREATED.into_response()
+            }
+        }
         Err(e) => JokeBaseError::response(StatusCode::BAD_REQUEST, e),
     }
 }

--- a/src/jokebase.rs
+++ b/src/jokebase.rs
@@ -131,6 +131,17 @@ impl JokeBase {
         self.write_jokes()?;
         Ok(())
     }
+
+    pub fn update(&mut self, index: &str, joke: Joke) -> Result<(), JokeBaseErr> {
+        if !self.jokemap.contains_key(index) {
+            return self.add(joke);
+        }
+        self.jokemap
+            .entry(index.to_string())
+            .and_modify(|x| *x = joke);
+        self.write_jokes()?;
+        Ok(())
+    }
 }
 
 impl IntoResponse for &JokeBase {

--- a/src/jokebase.rs
+++ b/src/jokebase.rs
@@ -132,15 +132,18 @@ impl JokeBase {
         Ok(())
     }
 
-    pub fn update(&mut self, index: &str, joke: Joke) -> Result<(), JokeBaseErr> {
+    pub fn update(&mut self, index: &str, joke: Joke) -> Result<u8, JokeBaseErr> {
         if !self.jokemap.contains_key(index) {
-            return self.add(joke);
+            return match self.add(joke) {
+                Ok(()) => Ok(201),
+                Err(e) => Err(e),
+            };
         }
         self.jokemap
             .entry(index.to_string())
             .and_modify(|x| *x = joke);
         self.write_jokes()?;
-        Ok(())
+        Ok(200)
     }
 }
 

--- a/src/jokebase.rs
+++ b/src/jokebase.rs
@@ -136,10 +136,7 @@ impl JokeBase {
 
     pub fn update(&mut self, index: &str, joke: Joke) -> Result<StatusCode, JokeBaseErr> {
         if !self.jokemap.contains_key(index) {
-            return match self.add(joke) {
-                Ok(()) => Ok(StatusCode::CREATED),
-                Err(e) => Err(e),
-            };
+            return Err(JokeBaseErr::NoJoke);
         }
         if joke.id.is_empty() {
             return Err(JokeBaseErr::JokeUnprocessable(index.to_string()));

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ use axum::{
     extract::{Path, State},
     http::StatusCode,
     response::{IntoResponse, Response},
-    routing::{delete, get, post},
+    routing::{delete, get, post, put},
     Json, Router,
 };
 extern crate fastrand;
@@ -76,7 +76,8 @@ async fn main() {
         .route("/joke", get(joke))
         .route("/joke/:id", get(get_joke))
         .route("/joke/add", post(post_joke))
-        .route("/joke/:id", delete(delete_joke));
+        .route("/joke/:id", delete(delete_joke))
+        .route("/joke/:id", put(update_joke));
 
     let swagger_ui = SwaggerUi::new("/swagger-ui").url("/api-docs/openapi.json", ApiDoc::openapi());
     let redoc_ui = Redoc::with_url("/redoc", ApiDoc::openapi());


### PR DESCRIPTION
### Description:
This PR add a PUT method and some additional minor tweaks to the joke API

1. **Add PUT method to update jokes:** A new endpoint has been added at /joke/:id to accept PUT requests, allowing users to update joke content. The happy path is the user updates an existing joke. 
2. This endpoint can return 200, 400, 404, and 422.
3. There is some minimal validation to make sure that the payload doesn't have an empty id string. If it does we return a 422.
4. Updated POST of a new joke to return a 201 (CREATED) on success

### Checklist

- [x] Code changes
- [x] Passes clippy and rustfmt
- [x] Updated swagger
- [x] Tested 200, 400, 404, 422 error code paths through swagger  