### PR TITLE
#20: Adding simple initial CI setup

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build
+      run: cargo clippy --release


### PR DESCRIPTION
### Description:
This PR adds a simple ci.yaml to have cargo clippy --release run on PR/push

1. 1 config file was added at `.github/workflows/ci.yaml`

### Checklist

- [x] Config changes
- [x] CI build passes when expected [passing build](https://github.com/relia1/knock-knock/actions/runs/9143895018/job/25141138782)
- [x] CI build fails when expected [failed build](https://github.com/relia1/knock-knock/actions/runs/9143954227/job/25141264510?pr=1)